### PR TITLE
Fix env var naming and separate declare and assign

### DIFF
--- a/shared/healthcheck.sh
+++ b/shared/healthcheck.sh
@@ -10,12 +10,14 @@ function main() {
     exit 1
   fi
 
-  export SQLCMDPASSWORD=${SA_PASSWORD:-$(< "${SA_PASSWORD_FILE}")}
+  declare SQLCMDPASSWORD
+  SQLCMDPASSWORD=${MSSQL_SA_PASSWORD:-$(< "${MSSQL_SA_PASSWORD_FILE}")}
+  export SQLCMDPASSWORD
 
   debug "Healthcheck query: ${health_check_query}, timeout: ${timeout_secs}."
 
   set +e
-  sqlcmd_output=$(/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -l ${timeout_secs} -t ${timeout_secs} -b -Q "${health_check_query}" 2>&1)
+  sqlcmd_output=$(/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -l "${timeout_secs}" -t "${timeout_secs}" -b -Q "${health_check_query}" 2>&1)
   exit_code=$?
   set -e
 


### PR DESCRIPTION
### ⚙️ Changes

This PR corrects the env var naming to supply to `sqlcmd` to use the newer `MSSQL_SA_PASSWORD`.  Additionally, the declaration and assignment is now separated to avoid masking errors.  Previously, this was causing the script to _not_ abort when it failed to read the env var and as a result, `sqlcmd` just hung waiting on stdin.

Fixes #9