### PR TITLE
Fix movement of mysql-tools in upstream 2019 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ HEALTHCHECK \
     --timeout=3s \
     CMD healthcheck.sh
 
-# Put CLI tools on the PATH
-ENV PATH /opt/mssql-tools/bin:$PATH
-
 # Setup a dedicated user for SQL Server (if missing), also set permissions on volume base
 ARG MSSQL_USERHOME=/home/mssql
 ARG MSSQL_UID=10001
@@ -44,7 +41,13 @@ RUN mkdir ${MSSQL_USERHOME} && \
     chown mssql:mssql /docker-entrypoint-initdb.d && \
     # Backup Folder
     mkdir /backups && \
-    chown mssql:mssql /backups
+    chown mssql:mssql /backups && \
+    # Workaround upstream placement of mssql-tools
+    find /opt -maxdepth 1 -regextype egrep -regex "/opt/mssql-tools[0-9]+" -type d -print0 -quit | xargs -0 -i ln -s {} /opt/mssql-tools && \
+    sqlcmd -? | head -n 3
+
+# Put CLI tools on the PATH
+ENV PATH /opt/mssql-tools/bin:$PATH
 
 # Return to mssql user
 USER mssql

--- a/shared/docker-entrypoint.sh
+++ b/shared/docker-entrypoint.sh
@@ -135,7 +135,7 @@ if [ ! -f "${MSSQL_BASE}/.docker-init-complete" ]; then
   if [ "${MSSQL_DATABASE}" ] && [ "${MSSQL_USER}" ] && [ "${MSSQL_PASSWORD}" ]; then
     info "Database healthy, proceeding with provisioning..."
     envsubst < "${MSSQL_PROVISIONING_FILE_TEMPLATE}" > "${MSSQL_PROVISIONING_FILE}"
-    if /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -b -i "${MSSQL_PROVISIONING_FILE}"; then
+    if sqlcmd -S localhost -U sa -b -C -i "${MSSQL_PROVISIONING_FILE}"; then
       info "Provisioning completed, database [${MSSQL_DATABASE}] created."
       rm "${MSSQL_PROVISIONING_FILE}"
     else

--- a/shared/healthcheck.sh
+++ b/shared/healthcheck.sh
@@ -17,7 +17,7 @@ function main() {
   debug "Healthcheck query: ${health_check_query}, timeout: ${timeout_secs}."
 
   set +e
-  sqlcmd_output=$(/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -l "${timeout_secs}" -t "${timeout_secs}" -b -Q "${health_check_query}" 2>&1)
+  sqlcmd_output=$(sqlcmd -S localhost -U sa -l "${timeout_secs}" -t "${timeout_secs}" -b -C -Q "${health_check_query}" 2>&1)
   exit_code=$?
   set -e
 


### PR DESCRIPTION
### ⚙️ Changes

In the `Dockerfile`, there is now a symlink creation if necessary (such as for the 2019 upstream image at the moment that has `/opt/mssql-tools18` instead of `/opt/mssql-tools` like before).  As an additional safeguard, we also now invoke `sqlcmd -?` which will break the build if not found on the path. 

I observed that the 2019/2022 images were still failing healthchecks after the above fix.  Exec'ing `healthcheck.sh -v` revealed TLS path verify error due to using `localhost` to loop back to the server.  Added `-C` to bypass cert validation for this loopback healthcheck.

Also some minor tidying of use of `sqlcmd` to always use the `PATH`.

### ☑️ Testing

I spooled up local copies of 2017, 2019, and 2022, all with initial databases.  Provisioning and healthchecks are working, and connections to each DB are successful.

Fixes #11