### PR TITLE
Added implicit trust for local loopback sqlcmd

### DIFF
--- a/shared/backup.sh
+++ b/shared/backup.sh
@@ -16,8 +16,8 @@ BACKUP_FILE="${BACKUP_TARGET}/${DATABASE_TARGET}_$(date +%Y%m%d_%H%M%S).bak"
 
 # Perform Database Backup
 echo "Initating backup of database [${DATABASE_TARGET}] to ${BACKUP_FILE}"
-/opt/mssql-tools/bin/sqlcmd \
-  -S localhost -U sa \
+sqlcmd \
+  -S localhost -U sa -C \
   -Q "BACKUP DATABASE [${DATABASE_TARGET}] TO DISK = N'${BACKUP_FILE}' WITH NOFORMAT, NOINIT, NAME = '${DATABASE_TARGET}-full', SKIP, NOREWIND, NOUNLOAD, STATS = 10"
 
 chmod 640 "${BACKUP_FILE}"

--- a/shared/docker-entrypoint.sh
+++ b/shared/docker-entrypoint.sh
@@ -110,7 +110,7 @@ if [ ! -f "${MSSQL_BASE}/.docker-init-complete" ]; then
 
   # Wait up to 60 seconds for database initialization to complete
   for ((i=${MSSQL_STARTUP_DELAY:=60};i>0;i--)); do
-    if /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -l 1 -t 1 -b -Q "SELECT 1" &> /dev/null; then
+    if sqlcmd -S localhost -U sa -l 1 -t 1 -b -C -Q "SELECT 1" &> /dev/null; then
       break
     fi
     sleep 1
@@ -121,7 +121,7 @@ if [ ! -f "${MSSQL_BASE}/.docker-init-complete" ]; then
   fi
 
   # Set SQLCMD command string for additional initialization file processing
-  sqlcmd=( sqlcmd -S localhost -U sa -l 3 -V 16 )
+  sqlcmd=( sqlcmd -S localhost -U sa -l 3 -V 16 -C )
 
   echo
   for f in /docker-entrypoint-initdb.d/*.bak /docker-entrypoint-initdb.d/*.sh /docker-entrypoint-initdb.d/*.sql; do


### PR DESCRIPTION
Building on #12, this addresses some missed areas where additional local loopback implicit trust of the server certificate is required with `sqlcmd` usage (via `-C` flag).

Fixes #11 